### PR TITLE
Configure luminosity definition and units

### DIFF
--- a/fancy/analysis/analysis.py
+++ b/fancy/analysis/analysis.py
@@ -330,9 +330,9 @@ class Analysis:
         # convert scale for sampling
         D = self.data.source.distance
         alpha_T = self.data.detector.alpha_T
-        L = self.model.L
+        Q = self.model.Q
         F0 = self.model.F0
-        D, alpha_T, eps, F0, L = convert_scale(D, alpha_T, eps, F0, L)
+        D, alpha_T, eps, F0, Q = convert_scale(D, alpha_T, eps, F0, Q)
 
         if (
             self.analysis_type == self.joint_type
@@ -357,7 +357,7 @@ class Analysis:
             "eps": eps,
         }
 
-        self.simulation_input["L"] = L
+        self.simulation_input["Q"] = Q
         self.simulation_input["F0"] = F0
         self.simulation_input["distance"] = self.data.source.distance
 

--- a/fancy/analysis/results.py
+++ b/fancy/analysis/results.py
@@ -61,7 +61,7 @@ class Results:
 
                         # reconstruct from other info
                         F0 = model["F0"][()]
-                        L = model["L"][()]
+                        Q = model["Q"][()]
                         D = f["source/distance"][()]
                         D = [d * Mpc_to_km for d in D]
 
@@ -82,14 +82,14 @@ class Results:
         Return mean values of all main fit parameters.
         """
 
-        list_of_keys = ["B", "alpha", "L", "F0", "lambda"]
+        list_of_keys = ["B", "alpha", "Q", "F0", "lambda"]
         chain = self.get_chain(list_of_keys)
 
         fit_parameters = {}
         fit_parameters["B"] = np.mean(chain["B"])
         fit_parameters["alpha"] = np.mean(chain["alpha"])
         fit_parameters["F0"] = np.mean(chain["F0"])
-        fit_parameters["L"] = np.mean(chain["L"])
+        fit_parameters["Q"] = np.mean(chain["Q"])
         try:
             fit_parameters["lambda"] = np.mean(np.transpose(chain["lambda"]), axis=1)
         except:
@@ -125,7 +125,7 @@ class Results:
         Run N posterior predictive simulations.
         """
 
-        keys = ["L", "F0", "alpha", "B"]
+        keys = ["Q", "F0", "alpha", "B"]
         fit_chain = self.get_chain(keys)
         input_data, detector, source = self.get_input_data()
 
@@ -169,7 +169,7 @@ class PPC:
         self.alpha = fit_chain["alpha"]
         self.B = fit_chain["B"]
         self.F0 = fit_chain["F0"]
-        self.L = fit_chain["L"]
+        self.Q = fit_chain["Q"]
 
         self.arrival_direction = Direction(input_data["arrival_direction"])
         self.Edet = input_data["Edet"]
@@ -192,7 +192,7 @@ class PPC:
             alpha = np.random.choice(self.alpha)
             B = np.random.choice(self.B)
             F0 = np.random.choice(self.F0)
-            L = np.random.choice(self.L)
+            Q = np.random.choice(self.Q)
 
             # calculate eps integral
             Eex = self.energy_loss.get_Eex(self.Eth_src, alpha)
@@ -222,7 +222,7 @@ class PPC:
                 "eps": eps,
             }
             self.ppc_input["B"] = B
-            self.ppc_input["L"] = np.tile(L, input_data["Ns"])
+            self.ppc_input["Q"] = np.tile(Q, input_data["Ns"])
             self.ppc_input["F0"] = F0
             self.ppc_input["alpha"] = alpha
             self.ppc_input["Eerr"] = input_data["Eerr"]

--- a/fancy/analysis/results.py
+++ b/fancy/analysis/results.py
@@ -65,7 +65,7 @@ class Results:
                         D = f["source/distance"][()]
                         D = [d * Mpc_to_km for d in D]
 
-                        Fs = sum([(l / (4 * np.pi * d**2)) for l, d in zip(L, D)])
+                        Fs = sum([(q / (4 * np.pi * d**2)) for q, d in zip(Q, D)])
                         f = Fs / (Fs + F0)
                         truths["f"] = f
 

--- a/fancy/interfaces/stan.py
+++ b/fancy/interfaces/stan.py
@@ -57,7 +57,7 @@ class Model:
         kappa: float = None,
         F_T: float = None,
         f: float = None,
-        L: float = None,
+        Q: float = None,
         F0: float = None,
         alpha: float = None,
         Eth: float = 50,
@@ -70,6 +70,7 @@ class Model:
         :param f: associated fraction
         :param kappa: deflection parameter
         :param B: rms B field strength [nG]
+        :param Q: Total Luminosity [yr^-1]
         :param alpha: source spectral index
         :param Eth: threshold energy of study [EeV]
         :param ptype: element of composition
@@ -78,7 +79,7 @@ class Model:
         self.f = f
         self.kappa = kappa
         self.B = B
-        self.L = L
+        self.Q = Q
         self.F0 = F0
         self.alpha = alpha
         self.Eth = Eth
@@ -95,7 +96,7 @@ class Model:
         self.properties["f"] = self.f
         self.properties["kappa"] = self.kappa
         self.properties["B"] = self.B
-        self.properties["L"] = self.L
+        self.properties["Q"] = self.Q
         self.properties["F0"] = self.F0
         self.properties["F0"] = self.F0
         self.properties["alpha"] = self.alpha
@@ -201,7 +202,7 @@ def convert_scale(D, alpha_T, eps, F0=None, L=None, to_stan=True):
     alpha_T [km^2 yr] -> alpha_T / 1000
     eps [km^2 yr] -> eps / 1000
     F [# km^-2 yr^-1] -> F * 1000
-    L [# yr^-1] -> L / 1e39
+    Q [# yr^-1] -> Q / 1e39
 
     Can also convert back by setting to_stan = False
     """
@@ -217,7 +218,7 @@ def convert_scale(D, alpha_T, eps, F0=None, L=None, to_stan=True):
             F0 = F0 * 1000.0
 
         if isinstance(L, (list, np.ndarray)):
-            L = L / 1.0e39
+            Q = Q / 1.0e39
 
     # Convert from Stan units to physical units
     else:
@@ -230,7 +231,7 @@ def convert_scale(D, alpha_T, eps, F0=None, L=None, to_stan=True):
             F0 = F0 / 1000.0
 
         if isinstance(L, (list, np.ndarray)):
-            L = L * 1.0e39
+            Q = Q * 1.0e39
 
     if F0 and isinstance(L, (list, np.ndarray)):
 
@@ -259,7 +260,7 @@ def get_simulation_input(Nsim, f, D, M, alpha_T):
     F0 = (1 - f) * FT
 
     # Assume equal luminosities
-    L = Fs / (sum([1 / (4 * np.pi * (d * Mpc_to_km) ** 2) for d in D]))
-    L = np.tile(L, len(D))  # yr^-1
+    Q = Fs / (sum([1 / (4 * np.pi * (d * Mpc_to_km) ** 2) for d in D]))
+    Q = np.tile(Q, len(D))  # yr^-1
 
-    return L, F0
+    return Q, F0

--- a/fancy/interfaces/stan.py
+++ b/fancy/interfaces/stan.py
@@ -194,7 +194,7 @@ def coord_to_uv(coord):
     return uv
 
 
-def convert_scale(D, alpha_T, eps, F0=None, L=None, to_stan=True):
+def convert_scale(D, alpha_T, eps, F0=None, Q=None, to_stan=True):
     """
     Convenience function to convert parameters
     to O(1) scale for sampling in Stan.
@@ -217,7 +217,7 @@ def convert_scale(D, alpha_T, eps, F0=None, L=None, to_stan=True):
         if F0:
             F0 = F0 * 1000.0
 
-        if isinstance(L, (list, np.ndarray)):
+        if isinstance(Q, (list, np.ndarray)):
             Q = Q / 1.0e39
 
     # Convert from Stan units to physical units
@@ -230,12 +230,12 @@ def convert_scale(D, alpha_T, eps, F0=None, L=None, to_stan=True):
         if F0:
             F0 = F0 / 1000.0
 
-        if isinstance(L, (list, np.ndarray)):
+        if isinstance(Q, (list, np.ndarray)):
             Q = Q * 1.0e39
 
-    if F0 and isinstance(L, (list, np.ndarray)):
+    if F0 and isinstance(Q, (list, np.ndarray)):
 
-        return D, alpha_T, eps, F0, L
+        return D, alpha_T, eps, F0, Q
 
     else:
 


### PR DESCRIPTION
We change the labelling from "L" (which should represent energy / time) to "Q" (which represents particles / time). This is done here also as the labelling in stan in kwat0308/uhecr_ta_paper is also changed from L-> Q.