### PR TITLE
Bugfix to use kappa_gmf from diff. gmf models

### DIFF
--- a/fancy/interfaces/data.py
+++ b/fancy/interfaces/data.py
@@ -45,7 +45,7 @@ class Data:
         # define source object
         self.source = new_source
 
-    def add_uhecr(self, filename, label=None, ptype="p"):
+    def add_uhecr(self, filename, label=None, ptype="p", gmf_model="JF12"):
         """
         Add a uhecr object to the data container from file.
 
@@ -55,7 +55,7 @@ class Data:
         """
 
         new_uhecr = Uhecr()
-        new_uhecr.from_data_file(filename, label, ptype)
+        new_uhecr.from_data_file(filename, label, ptype, gmf_model=gmf_model)
 
         # define uhecr object
         self.uhecr = new_uhecr

--- a/fancy/interfaces/uhecr.py
+++ b/fancy/interfaces/uhecr.py
@@ -89,7 +89,8 @@ class Uhecr:
             self.A = self._find_area(exp_factor)
 
             self.ptype = ptype
-            self.kappa_gmf = data["kappa_gmf"][gmf_model][ptype]["kappa_gmf"][()]
+            if "kappa_gmf" in data and gmf_model != "None":
+                self.kappa_gmf = data["kappa_gmf"][gmf_model][ptype]["kappa_gmf"][()]
 
     def _get_properties(self):
         """


### PR DESCRIPTION
There is a bug in the code where the GMF model associated to the kappa_GMF for each UHECR dataset is always reading the JF12 model. This isn't an issue for now, but will be when we investigate for different GMF models. So its better to treat the bugs early 😉 