### PR TITLE
Add try/except warning for ligo.skymap

### DIFF
--- a/fancy/plotting/allskymap.py
+++ b/fancy/plotting/allskymap.py
@@ -1,6 +1,13 @@
 import numpy as np
 from matplotlib import pyplot as plt
-import ligo.skymap.plot
+
+try:
+    import ligo.skymap.plot
+    ligo_plot_exists = True
+except:
+    ligo_plot_exists = False
+    pass
+
 from matplotlib.patches import PathPatch, Polygon
 from matplotlib.path import Path
 
@@ -53,6 +60,9 @@ class SphericalCircle(PathPatch):
     def __init__(
         self, center, radius, resolution=100, lon_0=0.0, vertex_unit=u.degree, **kwargs
     ):
+
+        if not ligo_plot_exists:
+            raise ImportError("ligo.skymap (>=py39) needs to be installed to use this functionality.")
 
         boundary = (lon_0 + 180) % 360
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
     tqdm
     h5py
     pyproj
-    ligo.skymap
     pandas
     cmdstanpy
     seaborn


### PR DESCRIPTION
Solves issue #31 . Also tested on a fresh conda installation with Python3.8.13.

The strict dependency of `ligo.skymap` is also removed.